### PR TITLE
Update to mime-db 1.53 to have audio/aac

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": "Liroo/react-native-mime-types",
   "dependencies": {
-    "mime-db": "~1.52.0"
+    "mime-db": "~1.53.0"
   },
   "devDependencies": {
     "eslint": "3.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,10 +711,10 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
-mime-db@~1.52.0:
-  version "1.52.0"
-  resolved "https://npm.klaxoon.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+mime-db@~1.53.0:
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.53.0.tgz#3cb63cd820fc29896d9d4e8c32ab4fcd74ccb447"
+  integrity sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==
 
 "minimatch@2 || 3", minimatch@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
Upgrade to [1.53](https://github.com/jshttp/mime-db/blob/master/HISTORY.md#1530--2024-07-12) since I was playing with audio/aac and failing to resolve the extension. 

> 1.53.0 / 2024-07-12
> Add extension .sql to application/sql
> Add extensions .aac and .adts to audio/aac